### PR TITLE
fix(layout): remove Vercel Analytics + Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,6 @@
         "@tiptap/extension-underline": "^3.22.4",
         "@tiptap/react": "^3.22.4",
         "@tiptap/starter-kit": "^3.22.4",
-        "@vercel/analytics": "^2.0.1",
-        "@vercel/speed-insights": "^2.0.0",
         "bcrypt": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -4934,86 +4932,6 @@
       },
       "peerDependencies": {
         "react": ">= 16.8.0"
-      }
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
-      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vercel/speed-insights": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
-      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,6 @@
     "@tiptap/extension-underline": "^3.22.4",
     "@tiptap/react": "^3.22.4",
     "@tiptap/starter-kit": "^3.22.4",
-    "@vercel/analytics": "^2.0.1",
-    "@vercel/speed-insights": "^2.0.0",
     "bcrypt": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,5 @@
 import type { Metadata, Viewport } from "next";
 import { Inter, Space_Grotesk, JetBrains_Mono } from "next/font/google";
-import { Analytics } from "@vercel/analytics/react";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import { NavbarShell } from "@/components/layout/NavbarShell";
 import { FooterShell } from "@/components/layout/FooterShell";
 import { ScrollProgress } from "@/components/layout/ScrollProgress";
@@ -152,8 +150,6 @@ export default async function RootLayout({
             <FooterShell />
             {enableCustomCursor && <CustomCursor />}
             <Toaster />
-            <Analytics />
-            <SpeedInsights />
           </PerformanceProvider>
         </QueryProvider>
       </body>


### PR DESCRIPTION
## Summary
- Brave Shields blocks `@vercel/analytics` and `@vercel/speed-insights` as trackers — the failed script loads were poisoning inline scripts after them, so buttons and the 3D canvas went dead in Brave.
- Remove both packages and their `<Analytics />` / `<SpeedInsights />` mounts from `app/layout.tsx`.
- Vercel's dashboard still shows basic deployment metrics without these client scripts.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] Site renders in Brave without disabling Shields

🤖 Generated with [Claude Code](https://claude.com/claude-code)