### PR TITLE
feat(motion): hand-rolled spring-physics engine + Button/Card

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { useMagnetic, useRipple } from "@/hooks/use-motion";
 
 interface ButtonProps {
   variant?: "primary" | "secondary";
@@ -11,6 +12,9 @@ interface ButtonProps {
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
+// "Engineered Motion" button: magnetic pull toward the cursor (outer
+// wrapper), press rebound + ripple ink on the inner surface. The two
+// transforms live on separate elements so they never fight.
 export function Button({
   variant = "primary",
   children,
@@ -18,23 +22,34 @@ export function Button({
   href,
   onClick,
 }: ButtonProps) {
+  const magnetic = useMagnetic<HTMLSpanElement>({ strength: 0.35, max: 6 });
+  const ripple = useRipple();
+
   return (
-    <motion.a
-      href={href}
-      onClick={onClick}
-      whileHover={{ y: -2 }}
-      whileTap={{ scale: 0.97, y: 1 }}
-      transition={{ type: "spring", stiffness: 400, damping: 15 }}
-      className={cn(
-        "group relative inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-        variant === "primary" &&
-          "bg-accent text-white shadow-lg shadow-accent/20 hover:shadow-xl hover:shadow-accent/30",
-        variant === "secondary" &&
-          "border border-border text-text-secondary hover:border-accent/50 hover:text-text",
-        className
-      )}
+    <span
+      ref={magnetic.ref}
+      onMouseMove={magnetic.onMouseMove}
+      onMouseLeave={magnetic.onMouseLeave}
+      className="inline-flex"
     >
-      {children}
-    </motion.a>
+      <motion.a
+        href={href}
+        onClick={onClick}
+        onMouseDown={ripple}
+        whileHover={{ y: -2 }}
+        whileTap={{ scale: 0.96 }}
+        transition={{ type: "spring", stiffness: 520, damping: 30 }}
+        className={cn(
+          "group relative inline-flex items-center justify-center gap-2 overflow-hidden rounded-full px-6 py-3 text-sm font-medium transition-[box-shadow,border-color,background-color,color] duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+          variant === "primary" &&
+            "bg-accent text-(--text-on-accent) shadow-(--glow-accent-sm) hover:shadow-(--glow-accent)",
+          variant === "secondary" &&
+            "border border-border text-text-secondary hover:border-accent/50 hover:text-text hover:shadow-(--glow-accent-sm)",
+          className,
+        )}
+      >
+        {children}
+      </motion.a>
+    </span>
   );
 }

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useRef, useCallback, type MouseEvent } from "react";
-import { motion, useMotionValue, useSpring } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { usePerformance } from "@/hooks/usePerformanceTier";
+import { useTilt } from "@/hooks/use-motion";
 
 interface CardProps {
   children: React.ReactNode;
@@ -11,71 +10,33 @@ interface CardProps {
   spotlight?: boolean;
 }
 
+// Engineered surface that tilts toward the cursor (hand-rolled spring
+// physics) with an accent spotlight tracking the pointer. Tilt/spotlight
+// are gated on the performance tier; reduced-motion collapses the tilt.
 export function Card({ children, className, spotlight = true }: CardProps) {
-  const ref = useRef<HTMLDivElement>(null);
   const perf = usePerformance();
-  const rotateX = useMotionValue(0);
-  const rotateY = useMotionValue(0);
-  const springRotateX = useSpring(rotateX, { stiffness: 300, damping: 20 });
-  const springRotateY = useSpring(rotateY, { stiffness: 300, damping: 20 });
-
-  const isPointerFine = useRef(
-    typeof window !== "undefined" && window.matchMedia("(pointer: fine)").matches
-  );
-
   const enableTilt = perf.enableCardTilt;
   const enableSpotlight = spotlight && perf.enableCardTilt;
-
-  const handleMouseMove = useCallback(
-    (e: MouseEvent<HTMLDivElement>) => {
-      if (!ref.current) return;
-      const rect = ref.current.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-
-      if (enableSpotlight) {
-        ref.current.style.setProperty("--spotlight-x", `${x}px`);
-        ref.current.style.setProperty("--spotlight-y", `${y}px`);
-      }
-
-      if (enableTilt && isPointerFine.current) {
-        rotateX.set(((y - rect.height / 2) / rect.height) * -8);
-        rotateY.set(((x - rect.width / 2) / rect.width) * 8);
-      }
-    },
-    [enableSpotlight, enableTilt, rotateX, rotateY]
-  );
-
-  const handleMouseLeave = useCallback(() => {
-    rotateX.set(0);
-    rotateY.set(0);
-  }, [rotateX, rotateY]);
+  const tilt = useTilt<HTMLDivElement>({ max: 8, spotlight: enableSpotlight });
 
   return (
-    <motion.div
-      ref={ref}
-      onMouseMove={enableTilt || enableSpotlight ? handleMouseMove : undefined}
-      onMouseLeave={enableTilt ? handleMouseLeave : undefined}
-      style={
-        enableTilt
-          ? {
-              rotateX: springRotateX,
-              rotateY: springRotateY,
-              transformPerspective: 800,
-            }
-          : undefined
-      }
+    <div
+      ref={tilt.ref}
+      onMouseMove={enableTilt || enableSpotlight ? tilt.onMouseMove : undefined}
+      onMouseLeave={enableTilt || enableSpotlight ? tilt.onMouseLeave : undefined}
       className={cn(
-        "group relative overflow-hidden rounded-xl glass-card glass-highlight p-6 transition-all duration-300 focus-within:ring-2 focus-within:ring-accent/30",
-        "hover:-translate-y-1 hover:shadow-[0_8px_40px_-12px_rgba(59,130,246,0.15)]",
+        "group relative overflow-hidden rounded-xl glass-card glass-highlight p-6 transition-shadow duration-300 focus-within:ring-2 focus-within:ring-accent/30",
+        // hover lift only applies when tilt is off (tilt owns the transform)
+        !enableTilt && "transition-[transform,box-shadow] hover:-translate-y-1",
+        "hover:shadow-(--glow-accent-sm)",
         enableSpotlight &&
           "after:pointer-events-none after:absolute after:inset-0 after:z-2 after:rounded-xl after:opacity-0 after:transition-opacity hover:after:opacity-100",
         enableSpotlight &&
-          "after:bg-[radial-gradient(400px_circle_at_var(--spotlight-x)_var(--spotlight-y),var(--accent-blue)/0.08,transparent_60%)]",
-        className
+          "after:bg-[radial-gradient(400px_circle_at_var(--spotlight-x)_var(--spotlight-y),var(--accent-soft),transparent_60%)]",
+        className,
       )}
     >
       {children}
-    </motion.div>
+    </div>
   );
 }

--- a/src/hooks/use-motion.ts
+++ b/src/hooks/use-motion.ts
@@ -1,0 +1,225 @@
+"use client";
+
+// ──────────────────────────────────────────────────────────────
+// "Engineered Motion" — hand-rolled spring-physics hooks.
+// Ported from the design system's components/motion.js. These hooks
+// drive the DOM directly via refs (no per-frame React re-render), so
+// motion stays buttery. The integration math mirrors the spring
+// configs in globals.css one-to-one.
+// ──────────────────────────────────────────────────────────────
+import { useRef, useCallback, useEffect, useState } from "react";
+
+const REDUCED =
+  typeof window !== "undefined" &&
+  window.matchMedia &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+export const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+// Semi-implicit Euler spring step. dt fixed at 1/60 for stability.
+function springStep(
+  p: number,
+  v: number,
+  target: number,
+  stiffness: number,
+  damping: number,
+  mass: number,
+): [number, number] {
+  const dt = 1 / 60;
+  const f = -stiffness * (p - target);
+  const d = -damping * v;
+  const a = (f + d) / mass;
+  const nv = v + a * dt;
+  const np = p + nv * dt;
+  return [np, nv];
+}
+
+// ── Magnetic pull ─────────────────────────────────────────────
+// Element drifts toward the cursor, then springs home on leave.
+export function useMagnetic<T extends HTMLElement = HTMLElement>({
+  strength = 0.3,
+  max = 6,
+  stiffness = 150,
+  damping = 15,
+}: { strength?: number; max?: number; stiffness?: number; damping?: number } = {}) {
+  const ref = useRef<T>(null);
+  const s = useRef({ x: 0, y: 0, vx: 0, vy: 0, tx: 0, ty: 0, raf: 0, running: false });
+
+  const loop = useCallback(() => {
+    const st = s.current;
+    [st.x, st.vx] = springStep(st.x, st.vx, st.tx, stiffness, damping, 1);
+    [st.y, st.vy] = springStep(st.y, st.vy, st.ty, stiffness, damping, 1);
+    if (ref.current) {
+      ref.current.style.transform = `translate(${st.x.toFixed(2)}px, ${st.y.toFixed(2)}px)`;
+    }
+    const settled =
+      Math.abs(st.x - st.tx) < 0.04 &&
+      Math.abs(st.y - st.ty) < 0.04 &&
+      Math.abs(st.vx) < 0.04 &&
+      Math.abs(st.vy) < 0.04;
+    if (settled) {
+      st.x = st.tx;
+      st.y = st.ty;
+      st.vx = 0;
+      st.vy = 0;
+      if (ref.current) ref.current.style.transform = `translate(${st.tx}px, ${st.ty}px)`;
+      st.running = false;
+      return;
+    }
+    st.raf = requestAnimationFrame(loop);
+  }, [stiffness, damping]);
+
+  const ensure = useCallback(() => {
+    const st = s.current;
+    if (!st.running) {
+      st.running = true;
+      st.raf = requestAnimationFrame(loop);
+    }
+  }, [loop]);
+
+  const onMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (REDUCED || !ref.current) return;
+      const r = ref.current.getBoundingClientRect();
+      const dx = e.clientX - (r.left + r.width / 2);
+      const dy = e.clientY - (r.top + r.height / 2);
+      s.current.tx = clamp(dx * strength, -max, max);
+      s.current.ty = clamp(dy * strength, -max, max);
+      ensure();
+    },
+    [strength, max, ensure],
+  );
+
+  const onMouseLeave = useCallback(() => {
+    s.current.tx = 0;
+    s.current.ty = 0;
+    ensure();
+  }, [ensure]);
+
+  useEffect(() => () => cancelAnimationFrame(s.current.raf), []);
+  return { ref, onMouseMove, onMouseLeave };
+}
+
+// ── 3D tilt + spotlight ───────────────────────────────────────
+// Card rotates toward the cursor; --spotlight-x/y track the pointer.
+export function useTilt<T extends HTMLElement = HTMLElement>({
+  max = 8,
+  stiffness = 220,
+  damping = 22,
+  spotlight = true,
+}: { max?: number; stiffness?: number; damping?: number; spotlight?: boolean } = {}) {
+  const ref = useRef<T>(null);
+  const s = useRef({ rx: 0, ry: 0, vrx: 0, vry: 0, trx: 0, try_: 0, raf: 0, running: false });
+
+  const loop = useCallback(() => {
+    const st = s.current;
+    [st.rx, st.vrx] = springStep(st.rx, st.vrx, st.trx, stiffness, damping, 1);
+    [st.ry, st.vry] = springStep(st.ry, st.vry, st.try_, stiffness, damping, 1);
+    if (ref.current) {
+      ref.current.style.transform = `perspective(900px) rotateX(${st.rx.toFixed(2)}deg) rotateY(${st.ry.toFixed(2)}deg)`;
+    }
+    const settled =
+      Math.abs(st.rx - st.trx) < 0.02 &&
+      Math.abs(st.ry - st.try_) < 0.02 &&
+      Math.abs(st.vrx) < 0.02 &&
+      Math.abs(st.vry) < 0.02;
+    if (settled) {
+      st.rx = st.trx;
+      st.ry = st.try_;
+      st.vrx = 0;
+      st.vry = 0;
+      if (st.trx === 0 && st.try_ === 0 && ref.current) ref.current.style.transform = "";
+      st.running = false;
+      return;
+    }
+    st.raf = requestAnimationFrame(loop);
+  }, [stiffness, damping]);
+
+  const ensure = useCallback(() => {
+    const st = s.current;
+    if (!st.running) {
+      st.running = true;
+      st.raf = requestAnimationFrame(loop);
+    }
+  }, [loop]);
+
+  const onMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (REDUCED || !ref.current) return;
+      const r = ref.current.getBoundingClientRect();
+      const px = (e.clientX - r.left) / r.width;
+      const py = (e.clientY - r.top) / r.height;
+      s.current.trx = clamp((0.5 - py) * 2 * max, -max, max);
+      s.current.try_ = clamp((px - 0.5) * 2 * max, -max, max);
+      if (spotlight) {
+        ref.current.style.setProperty("--spotlight-x", `${e.clientX - r.left}px`);
+        ref.current.style.setProperty("--spotlight-y", `${e.clientY - r.top}px`);
+      }
+      ensure();
+    },
+    [max, spotlight, ensure],
+  );
+
+  const onMouseLeave = useCallback(() => {
+    s.current.trx = 0;
+    s.current.try_ = 0;
+    ensure();
+  }, [ensure]);
+
+  useEffect(() => () => cancelAnimationFrame(s.current.raf), []);
+  return { ref, onMouseMove, onMouseLeave };
+}
+
+// ── Ripple ink on press ───────────────────────────────────────
+// Spawns a ripple from the pointer inside a positioned host.
+export function useRipple() {
+  return useCallback((e: React.MouseEvent) => {
+    if (REDUCED) return;
+    const host = e.currentTarget as HTMLElement;
+    const r = host.getBoundingClientRect();
+    const size = Math.max(r.width, r.height);
+    const span = document.createElement("span");
+    span.className = "ds-ripple-ink";
+    span.style.width = span.style.height = `${size}px`;
+    const cx = (e.clientX ?? r.left + r.width / 2) - r.left - size / 2;
+    const cy = (e.clientY ?? r.top + r.height / 2) - r.top - size / 2;
+    span.style.left = `${cx}px`;
+    span.style.top = `${cy}px`;
+    host.appendChild(span);
+    span.addEventListener("animationend", () => span.remove());
+  }, []);
+}
+
+// ── Driven numeric spring (returns live value, re-renders) ────
+// For controls where React must read the value (slider fill, switch).
+export function useSpringValue(
+  target: number,
+  { stiffness = 420, damping = 30, mass = 1 }: { stiffness?: number; damping?: number; mass?: number } = {},
+) {
+  const [value, setValue] = useState(target);
+  const s = useRef({ p: target, v: 0, raf: 0 });
+  useEffect(() => {
+    if (REDUCED) {
+      setValue(target);
+      return;
+    }
+    cancelAnimationFrame(s.current.raf);
+    const tick = () => {
+      const st = s.current;
+      [st.p, st.v] = springStep(st.p, st.v, target, stiffness, damping, mass);
+      if (Math.abs(st.p - target) < 0.001 && Math.abs(st.v) < 0.001) {
+        st.p = target;
+        st.v = 0;
+        setValue(target);
+        return;
+      }
+      setValue(st.p);
+      st.raf = requestAnimationFrame(tick);
+    };
+    s.current.raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(s.current.raf);
+  }, [target, stiffness, damping, mass]);
+  return value;
+}
+
+export const prefersReducedMotion = REDUCED;


### PR DESCRIPTION
## What

**PR 2 of 3.** Ports the design system's hand-rolled spring-physics motion engine (`components/motion.js`) to a typed React hook module and applies it to the core interactive primitives — the "every control feels like a real object you press" signature of the design.

### Changes
- **`hooks/use-motion.ts`** — `useMagnetic`, `useTilt`, `useRipple`, `useSpringValue`, `clamp`. A semi-implicit Euler spring integrator that drives the DOM directly via refs (no per-frame React re-render), mirroring the spring configs in `globals.css`. Honors `prefers-reduced-motion`.
- **`Button`** — magnetic pull toward the cursor (outer wrapper) + press rebound + ripple ink, accent glow on hover. Uses `--text-on-accent` so the label stays legible across every switchable accent.
- **`Card`** — hand-rolled cursor tilt + accent spotlight (replaces the framer-motion `useSpring` tilt), accent-derived glow/spotlight instead of a hardcoded blue. Tilt/spotlight gated on the performance tier.

Public component APIs are unchanged, so no callers need updating.

## Verification
- ✅ `npm run typecheck` clean
- ✅ `npm run build` clean

## Merge order
Depends on the design tokens in **#48** (ripple class, `--glow-accent*`, `--accent-soft`, `--text-on-accent`). **Merge #48 first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)