### PR TITLE
fix(media): accept relative media URLs and render education logo

### DIFF
--- a/src/components/sections/EducationSection.tsx
+++ b/src/components/sections/EducationSection.tsx
@@ -51,9 +51,18 @@ export function EducationSection({ education, community }: EducationSectionProps
           {education && (
             <motion.div variants={fadeInUp}>
               <Card spotlight={false}>
-                <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-accent/10">
-                  <GraduationCap size={18} className="text-accent" />
-                </div>
+                {education.logoImage?.url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={education.logoImage.url}
+                    alt={`${education.school} logo`}
+                    className="mb-4 h-10 w-10 rounded-full object-contain"
+                  />
+                ) : (
+                  <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-accent/10">
+                    <GraduationCap size={18} className="text-accent" />
+                  </div>
+                )}
                 <h3 className="font-display text-lg font-semibold text-text">{education.school}</h3>
                 <p className="text-sm text-text-secondary">{education.degree}</p>
                 <div className="mt-3 flex flex-wrap gap-3 text-xs text-text-tertiary">

--- a/src/lib/validations/shared.ts
+++ b/src/lib/validations/shared.ts
@@ -4,9 +4,16 @@ export const objectIdString = z
   .string()
   .regex(/^[a-fA-F0-9]{24}$/, "Invalid id");
 
+// Media URLs are stored as relative paths (`/api/media/<id>`), so a full
+// `z.string().url()` check would reject them. Accept either an absolute URL
+// or a root-relative path.
+const mediaUrlString = z
+  .string()
+  .refine((v) => v === "" || v.startsWith("/") || /^https?:\/\//.test(v), "Invalid url");
+
 export const mediaRefSchema = z
   .object({
-    url: z.string().url().or(z.literal("")).optional(),
+    url: mediaUrlString.optional(),
     mediaId: objectIdString.optional(),
   })
   .partial()


### PR DESCRIPTION
## What
- `mediaRefSchema` rejected the relative `/api/media/<id>` URLs the upload pipeline produces (`z.string().url()` requires an absolute URL), causing any save with a profile/cover/logo image to 400 with `"Invalid url"`. Now accepts root-relative paths and empty strings alongside absolute URLs.
- `EducationSection` now renders the uploaded school `logoImage` when present, falling back to the `GraduationCap` icon.

## Why
Uploading an education logo succeeded but the PATCH save 400'd, and even once saved the logo had nowhere to render on the public page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)