### PR TITLE
fix(ui): body hydration warning + refresh public cache after Postgres migration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -158,7 +158,7 @@ export default async function RootLayout({
           />
         )}
       </head>
-      <body className="bg-bg text-text antialiased">
+      <body className="bg-bg text-text antialiased" suppressHydrationWarning>
         <QueryProvider>
           <PerformanceProvider>
             {children}

--- a/src/lib/queries/content.ts
+++ b/src/lib/queries/content.ts
@@ -46,8 +46,10 @@ async function safeMany<T>(fn: () => Promise<T[]>, scope: string): Promise<T[]> 
   }
 }
 
+// `pg` keypart busts the Mongo-era cache entries once on deploy; `revalidate`
+// lets content self-heal if the DB is changed outside the admin flow.
 const cached = <T>(fn: () => Promise<T>, key: string, tag: string): (() => Promise<T>) =>
-  unstable_cache(fn, [key], { tags: [tag, CACHE_TAGS.all] });
+  unstable_cache(fn, [key, "pg"], { tags: [tag, CACHE_TAGS.all], revalidate: 300 });
 
 export const getHero = cached(
   () =>

--- a/src/lib/queries/site.ts
+++ b/src/lib/queries/site.ts
@@ -33,8 +33,8 @@ export const getSiteSettings = unstable_cache(
       return null;
     }
   },
-  ["site-settings"],
-  { tags: [CACHE_TAGS.settings, CACHE_TAGS.all] },
+  ["site-settings", "pg"],
+  { tags: [CACHE_TAGS.settings, CACHE_TAGS.all], revalidate: 300 },
 );
 
 export const getHomeSections = unstable_cache(
@@ -50,8 +50,8 @@ export const getHomeSections = unstable_cache(
       return [];
     }
   },
-  ["home-sections"],
-  { tags: [CACHE_TAGS.sections, CACHE_TAGS.all] },
+  ["home-sections", "pg"],
+  { tags: [CACHE_TAGS.sections, CACHE_TAGS.all], revalidate: 300 },
 );
 
 export const getNavItems = unstable_cache(
@@ -68,6 +68,6 @@ export const getNavItems = unstable_cache(
       return [];
     }
   },
-  ["nav-items"],
-  { tags: [CACHE_TAGS.nav, CACHE_TAGS.all] },
+  ["nav-items", "pg"],
+  { tags: [CACHE_TAGS.nav, CACHE_TAGS.all], revalidate: 300 },
 );


### PR DESCRIPTION
## Summary
- **Hydration warning:** add `suppressHydrationWarning` to `<body>`. Browser extensions inject `__processed_*` attributes onto `<body>` before React hydrates, causing the reported mismatch. `<html>` already had it.
- **Stale public content:** the ETL imported all content directly into Postgres, but `unstable_cache` had already cached the pre-import (empty) results with no TTL. Bumped the cache keyparts (`"pg"`) to force a one-time fresh read on deploy, and added `revalidate: 300` so content self-heals if the DB changes outside the admin flow.

## Verify
- `lint` / `typecheck` / `build` clean.
- After deploy, the public page shows all sections (projects, skills, experience, etc.) from the migrated data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)